### PR TITLE
Mention the DWiki entry in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,4 +13,4 @@ documentation, and some articles.
 * [Wiki](https://wiki.dlang.org/)
 
 If you wish to contribute to the website or language documentation, please see
-the [CONTRIBUTING.md file] (CONTRIBUTING.md).
+the [CONTRIBUTING.md file](CONTRIBUTING.md) and [wiki entry](https://wiki.dlang.org/Contributing_to_dlang.org).


### PR DESCRIPTION
I think the wiki entry is poorly referenced - I couldn't find a single link here.
(in general I think that the wiki entry should be merged with the `CONTRIBUTING.md`).