### PR TITLE
Add link to betterC in the compiler manual

### DIFF
--- a/spec/betterc.dd
+++ b/spec/betterc.dd
@@ -51,6 +51,8 @@ $(OL
     $(LI `unittest` (testing can be as usual with the `-betterC` flag))
 )
 
+The exact behavior of the `-betterC` switch is documented at the $(LINK2 $(ROOT_DIR)dmd.html#switch-betterC, compiler manual).
+
 $(SPEC_SUBNAV_PREV simd, Vector Extensions)
 
 )


### PR DESCRIPTION
There's also [Walter's great post](https://dlang.org/blog/2017/08/23/d-as-a-better-c), but I'm not sure whether linking to this can be done as part of the official spec.
Anyhow this page is the only one that shows up when one searches for "betterC" in Google:

![image](https://user-images.githubusercontent.com/4370550/30378120-7111659a-9892-11e7-8a39-3adada199bc2.png)
